### PR TITLE
make Output::Error contain Content not String

### DIFF
--- a/src/engine/dag.rs
+++ b/src/engine/dag.rs
@@ -4,7 +4,7 @@ use crate::{
     utils::EnvVar,
     Action, Parser,
 };
-use log::{debug, error, info};
+use log::{debug, error};
 use std::{
     collections::HashMap,
     panic::{self, AssertUnwindSafe},
@@ -436,7 +436,7 @@ impl Dag {
                             "Execution failed [name: {}, id: {}]\nerr: {}",
                             task_name,
                             task_id,
-                            out.get_err().unwrap_or("".to_string())
+                            out.get_err().unwrap_or("DAGRS: couldn't parse error message".to_string())
                         );
                         ExecResult::Failure
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub use derive::*;
 pub use engine::{Dag, DagError, Engine, OutputMessage};
 pub use task::{
     alloc_id, Action, CommandAction, Complex, DefaultTask, Input, Output, Simple, Task,
+    ToErrorMessage,
 };
 pub use utils::{EnvVar, ParseError, Parser};
 #[cfg(feature = "yaml")]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -32,7 +32,7 @@ pub use self::cmd::CommandAction;
 pub use self::default_task::DefaultTask;
 pub use self::state::Content;
 pub(crate) use self::state::ExecState;
-pub use self::state::{Input, Output};
+pub use self::state::{Input, Output, ToErrorMessage};
 
 mod action;
 mod cmd;

--- a/src/task/state.rs
+++ b/src/task/state.rs
@@ -36,7 +36,8 @@
 //! to implement the logic of the program.
 
 use std::{
-    any::Any, fmt::Debug, slice::Iter, sync::{
+    any::Any, fmt::Debug, slice::Iter,
+    sync::{
         atomic::{AtomicBool, AtomicPtr, Ordering},
         Arc,
     }

--- a/src/task/state.rs
+++ b/src/task/state.rs
@@ -36,12 +36,10 @@
 //! to implement the logic of the program.
 
 use std::{
-    any::Any,
-    slice::Iter,
-    sync::{
+    any::Any, fmt::Debug, slice::Iter, sync::{
         atomic::{AtomicBool, AtomicPtr, Ordering},
         Arc,
-    },
+    }
 };
 
 use tokio::sync::Semaphore;
@@ -71,6 +69,10 @@ impl Content {
     pub fn into_inner<H: Send + Sync + 'static>(self) -> Option<Arc<H>> {
         self.content.downcast::<H>().ok()
     }
+
+    pub fn to_error_message<H: ToErrorMessage + 'static>(self) -> String {
+        self.content.downcast_ref::<H>().unwrap().to_error_message()
+    }
 }
 
 /// [`ExeState`] internally stores [`Output`], which represents whether the execution of
@@ -96,7 +98,7 @@ pub(crate) struct ExecState {
 #[derive(Debug, Clone)]
 pub enum Output {
     Out(Option<Content>),
-    Err(String),
+    Err(Option<Content>),
     ErrWithExitCode(Option<i32>, Option<Content>),
     Termination,
 }
@@ -104,6 +106,17 @@ pub enum Output {
 /// Task's input value.
 #[derive(Debug)]
 pub struct Input(Vec<Content>);
+
+pub trait ToErrorMessage {
+    fn to_error_message(&self) -> String;
+}
+
+// backward compatibility
+impl ToErrorMessage for String {
+    fn to_error_message(&self) -> String {
+        self.clone()
+    }
+}
 
 impl ExecState {
     /// Construct a new [`ExeState`].
@@ -184,8 +197,8 @@ impl Output {
     }
 
     /// Construct an [`Output`]` with an error message.
-    pub fn error(msg: String) -> Self {
-        Self::Err(msg)
+    pub fn error<H: Send + Sync + Debug + ToErrorMessage + 'static>(msg: H) -> Self {
+        Self::Err(Some(Content::new(msg)))
     }
 
     /// Construct an [`Output`]` with an exit code and an optional error message.
@@ -209,7 +222,8 @@ impl Output {
     pub(crate) fn get_out(&self) -> Option<Content> {
         match self {
             Self::Out(ref out) => out.clone(),
-            Self::Err(_) | Self::ErrWithExitCode(_, _) | Self::Termination => None,
+            Self::Err(ref out) => out.clone(),
+            Self::ErrWithExitCode(_, _) | Self::Termination => None,
         }
     }
 
@@ -217,7 +231,18 @@ impl Output {
     pub(crate) fn get_err(&self) -> Option<String> {
         match self {
             Self::Out(_) | Self::Termination => None,
-            Self::Err(err) => Some(err.to_string()),
+            Self::Err(err) => {
+                err
+                    .as_ref()
+                    .map(|content| {
+                        // TODO: this `get` here always returns None
+                        content
+                            .get::<Box<dyn ToErrorMessage>>()
+                            .map(|m| m.to_error_message())
+                    })
+                    .flatten()
+
+            }
             Self::ErrWithExitCode(_, err) => {
                 if let Some(e) = err {
                     Some(e.get::<String>()?.to_string())


### PR DESCRIPTION
This works for as much as we need to, but the TODO about Box<dyn ToErrorMessage> should better be addressed if possible at all